### PR TITLE
fix: call wont resolve when no return value in bind side

### DIFF
--- a/packages/vscode-channel/src/index.ts
+++ b/packages/vscode-channel/src/index.ts
@@ -73,9 +73,7 @@ export default class Channel<WebViewStateType = unknown> {
         const message: ChannelEventMessage<TRequest, TResponse> = event.data;
         if (method === message.method) {
           const data = await listener(message.request);
-          if (data) {
-            this.vscode!.postMessage({ ...message, response: data });
-          }
+          this.vscode!.postMessage({ ...message, response: data });
         }
       });
     } else if (this.context && this.webview) {
@@ -83,9 +81,7 @@ export default class Channel<WebViewStateType = unknown> {
         async (message: ChannelEventMessage<TRequest, TResponse>) => {
           if (method === message.method) {
             const data = await listener(message.request);
-            if (data) {
-              this.webview!.postMessage({ ...message, response: data });
-            }
+            this.webview!.postMessage({ ...message, response: data });
           }
         },
         undefined,


### PR DESCRIPTION
修复了 bind 没有返回值的时候，call 这一侧收不到消息，不会 resolve 的 bug

之前这个例子没法 resolve

```ts
/** Set picgo config */
export const setConfig = async (...args: Parameters<PicgoAPI['setConfig']>) =>
  await channel.call(W2VMessage.SET_CONFIG, args)
```

```ts
channel.bind<Parameters<PicgoAPI['setConfig']>>(
    W2VMessage.SET_CONFIG,
    (request) => {
      // 这里返回值是 void
      return PicgoAPI.picgoAPI.setConfig(...request)
    }
  )
```